### PR TITLE
Helix enable soft wrap in config

### DIFF
--- a/HOME_config/fish/config.fish
+++ b/HOME_config/fish/config.fish
@@ -1,5 +1,6 @@
 # My preferences
 fish_vi_key_bindings
+fish_config theme choose dracula
 set --export EDITOR hx
 
 # fzf keybindings

--- a/HOME_config/helix/config.toml
+++ b/HOME_config/helix/config.toml
@@ -1,5 +1,8 @@
 theme = "dracula"
 
+[editor.soft-wrap]
+enable = true
+
 [keys.normal]
 X = "extend_line_above" # do the opposite of "x"
 


### PR DESCRIPTION
## What changed
- Update `helix` config to always enable soft-wrap for horizontally wrapping text that would otherwise go off screen
- Always enable "Dracula" theme from fish config. Otherwise it seems to get dropped on new fish shells